### PR TITLE
#3 regexp parens

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See [action.yml](./action.yml)
 steps:
 - uses: deepakputhraya/action-pr-title@master
   with:
-    regex: '^(#\d+ )?- \w+' # Regex the title should match. By default, expects title to start with issue number, like: "#23 - title" or a dash, like: "- title"
+    regex: '^(#\d+ )?- .+' # Regex the title should match. By default, expects title to start with issue number, like: "#23 - title" or a dash, like: "- title"
     allowed_prefixes: 'feature,fix,JIRA' # title should start with the given prefix, empty by default
     disallowed_prefixes: 'feat/,hotfix' # title should not start with the given prefix, empty by default
     prefix_case_sensitive: false # title prefix are case insensitive. Default: false

--- a/Readme.md
+++ b/Readme.md
@@ -11,19 +11,19 @@ See [action.yml](./action.yml)
 steps:
 - uses: deepakputhraya/action-pr-title@master
   with:
-    regex: '([a-z])+\/([a-z])+' # Regex the title should match.
-    allowed_prefixes: 'feature,fix,JIRA' # title should start with the given prefix
-    disallowed_prefixes: 'feat/,hotfix' # title should not start with the given prefix
-    prefix_case_sensitive: false # title prefix are case insensitive
-    min_length: 5 # Min length of the title
-    max_length: 20 # Max length of the title
+    regex: '^(#\d+ )?- \w+' # Regex the title should match. By default, expects title to start with issue number, like: "#23 - title" or a dash, like: "- title"
+    allowed_prefixes: 'feature,fix,JIRA' # title should start with the given prefix, empty by default
+    disallowed_prefixes: 'feat/,hotfix' # title should not start with the given prefix, empty by default
+    prefix_case_sensitive: false # title prefix are case insensitive. Default: false
+    min_length: 5 # Min length of the title. Default: 1
+    max_length: 20 # Max length of the title. Default: -1
     github_token: ${{ github.token }} # Default: ${{ github.token }}
 ```
 
 ### Note:
-Ensure to add `types` to the Pull requests webhook event as by default workflows are triggered only 
-for `opened`, `synchronize`, or `reopened` pull request events. Read more about 
-it [here](https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull_request). 
+Ensure to add `types` to the Pull requests webhook event as by default workflows are triggered only
+for `opened`, `synchronize`, or `reopened` pull request events. Read more about
+it [here](https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull_request).
 ```yaml
 on:
   pull_request:

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Pull Request title rules'
+name: 'Blumilk Pull Request title rules'
 description: 'Github action to enforce Pull Request title conventions'
 author: 'deepakputhraya'
 inputs:

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
   regex:
     description: 'Regex to validate the pull request title'
     required: false
-    default: '^(#\d+ )?- \w+'
+    default: '^(#\d+ )?- .+'
   allowed_prefixes:
     description: 'Comma separated list of prefix allowed to be used in title. eg: feature,hotfix,JIRA-'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
   regex:
     description: 'Regex to validate the pull request title'
     required: false
-    default: '.+'
+    default: '^(#\d+ )?- \w+'
   allowed_prefixes:
     description: 'Comma separated list of prefix allowed to be used in title. eg: feature,hotfix,JIRA-'
     required: false


### PR DESCRIPTION
This PR tweaks the default regexp so that titles starting with non-word characters (like parens) can pass

should close #1 