### PR TITLE
Add verbal-description to the failure message when the regex fails

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -17,6 +17,7 @@ steps:
     prefix_case_sensitive: false # title prefix are case insensitive
     min_length: 5 # Min length of the title
     max_length: 20 # Max length of the title
+    verbal_description: 'Two words with a slash (/) between' # Verbal description of the regex rule
     github_token: ${{ github.token }} # Default: ${{ github.token }}
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: 'Max length of title. -1 to ignore the rule'
     required: false
     default: '-1'
+  verbal_description:
+    description: 'Description of the title rules to display when the action fails'
+    required: false
+    default: ''
   github_token:
     description: >
       Personal access token (PAT) used to fetch the repository. The PAT is configured

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ function validateTitlePrefix(title, prefix, caseSensitive) {
 
 async function run() {
     try {
+        const verbalDescription = core.getInput('verbal_description')
         const authToken = core.getInput('github_token', {required: true})
         const eventName = github.context.eventName;
         core.info(`Event name: ${eventName}`);
@@ -36,13 +37,15 @@ async function run() {
         });
 
         const title = pullRequest.title;
-        
+
         core.info(`Pull Request title: "${title}"`);
 
         // Check if title pass regex
         const regex = RegExp(core.getInput('regex'));
         if (!regex.test(title)) {
-            core.setFailed(`Pull Request title "${title}" failed to pass match regex - ${regex}`);
+            const messageSuffix = verbalDescription ? `rule - ${verbalDescription}` : `match regex - ${regex}`;
+
+            core.setFailed(`Pull Request title "${title}" failed to pass ${messageSuffix}`);
             return
         }
 


### PR DESCRIPTION
Adding a verbal description will help developers understand with better ease how to format the PR title.

Instead of seeing something like:
![](https://user-images.githubusercontent.com/8065975/131848781-70dd12d0-f6e8-48cb-8ac7-c437c7dc1c2c.png)

They will see an actual verbose description.