### PR TITLE
feat: Document github token permission

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,5 +32,22 @@ on:
 
 Triggering the action on anything other than `pull_request` will cause a failure.
 
+## Permissions
+
+In case the action fails with the following error:
+
+```
+Event name: pull_request
+Error: Resource not accessible by integration
+```
+
+You can fix this, by adding the following to your workflow:
+
+
+```yaml
+permissions:
+  pull-requests: read
+```
+
 ## License
 The scripts and documentation in this project are released under the [MIT License](./LICENSE)


### PR DESCRIPTION
I don't fully understand this myself, but this is what happened: I integrated the  action-pr-title action in one of our repos at work. The action worked fine without specifying any permissions. Then I forked that repo and the action-pr-title action broke in my fork. The fix was to specify the pull-request permission.